### PR TITLE
Mob 13 : Create the Amplitude analytics provider

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidCoreVersion"
     implementation "androidx.core:core-ktx:$androidCoreVersion"
 
+    implementation "com.amplitude:android-sdk:$amplitudeVersion"
+
     testImplementation "junit:junit:$junitVersion"
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$mockitoKotlinVersion"
     testImplementation "org.mockito:mockito-inline:$mockitoInlineVersion"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,1 +1,5 @@
-<manifest package="com.safeboda.commons" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.safeboda.commons">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+</manifest>

--- a/app/src/main/java/com/safeboda/commons/analytics/provider/amplitude/AmplitudeAnalyticsProvider.kt
+++ b/app/src/main/java/com/safeboda/commons/analytics/provider/amplitude/AmplitudeAnalyticsProvider.kt
@@ -2,14 +2,14 @@ package com.safeboda.commons.analytics.provider.amplitude
 
 import android.app.Application
 import com.amplitude.api.Amplitude
-import com.safeboda.commons.R
 import com.safeboda.commons.analytics.entity.AnalyticsEvent
 import com.safeboda.commons.analytics.entity.AnalyticsUser
 import com.safeboda.commons.analytics.provider.AnalyticsProvider
+import org.json.JSONObject
 
-class AmplitudeAnalyticsProvider(app: Application) : AnalyticsProvider {
+class AmplitudeAnalyticsProvider(app: Application, apiKey: String) : AnalyticsProvider {
     private val amplitude = Amplitude.getInstance()
-        .initialize(app.baseContext, app.getString(R.))
+        .initialize(app.baseContext, apiKey)
         .enableForegroundTracking(app)
 
     override fun setUser(user: AnalyticsUser) {

--- a/app/src/main/java/com/safeboda/commons/analytics/provider/amplitude/AmplitudeAnalyticsProvider.kt
+++ b/app/src/main/java/com/safeboda/commons/analytics/provider/amplitude/AmplitudeAnalyticsProvider.kt
@@ -15,6 +15,8 @@ class AmplitudeAnalyticsProvider(app: Application, apiKey: String) : AnalyticsPr
     companion object {
         private const val JSON_USER_MAIL = "mail"
         private const val JSON_USER_AGE = "age"
+
+        private const val JSON_USER_LOGGED_IN = "is_user_logged_in"
     }
 
     override fun setUser(user: AnalyticsUser) {
@@ -31,11 +33,11 @@ class AmplitudeAnalyticsProvider(app: Application, apiKey: String) : AnalyticsPr
     }
 
     override fun setUserLogged() {
-        amplitude.
+        setUserSessionStatus(true)
     }
 
     override fun setUserNotLogged() {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        setUserSessionStatus(false)
     }
 
     override fun track(event: AnalyticsEvent) {
@@ -46,5 +48,13 @@ class AmplitudeAnalyticsProvider(app: Application, apiKey: String) : AnalyticsPr
         }
 
         amplitude.logEvent(event.name, jsonObject)
+    }
+
+    private fun setUserSessionStatus(isLoggedIn: Boolean) {
+        val jsonObject = JSONObject().apply {
+            put(JSON_USER_LOGGED_IN, isLoggedIn)
+        }
+
+        amplitude.setUserProperties(jsonObject)
     }
 }

--- a/app/src/main/java/com/safeboda/commons/analytics/provider/amplitude/AmplitudeAnalyticsProvider.kt
+++ b/app/src/main/java/com/safeboda/commons/analytics/provider/amplitude/AmplitudeAnalyticsProvider.kt
@@ -12,9 +12,18 @@ class AmplitudeAnalyticsProvider(app: Application, apiKey: String) : AnalyticsPr
         .initialize(app.baseContext, apiKey)
         .enableForegroundTracking(app)
 
+    companion object {
+        private const val JSON_USER_MAIL = "mail"
+        private const val JSON_USER_AGE = "age"
+    }
+
     override fun setUser(user: AnalyticsUser) {
-        amplitude.userId = user.id.toString()
-        amplitude.setUserProperties()
+        val jsonObject = JSONObject().apply {
+            put(JSON_USER_MAIL, user.email)
+            put(JSON_USER_AGE, user.id)
+        }
+
+        amplitude.setUserProperties(jsonObject)
     }
 
     override fun clearUser() {

--- a/app/src/main/java/com/safeboda/commons/analytics/provider/amplitude/AmplitudeAnalyticsProvider.kt
+++ b/app/src/main/java/com/safeboda/commons/analytics/provider/amplitude/AmplitudeAnalyticsProvider.kt
@@ -8,6 +8,7 @@ import com.safeboda.commons.analytics.provider.AnalyticsProvider
 import org.json.JSONObject
 
 class AmplitudeAnalyticsProvider(app: Application, apiKey: String) : AnalyticsProvider {
+
     private val amplitude = Amplitude.getInstance()
         .initialize(app.baseContext, apiKey)
         .enableForegroundTracking(app)
@@ -57,4 +58,5 @@ class AmplitudeAnalyticsProvider(app: Application, apiKey: String) : AnalyticsPr
 
         amplitude.setUserProperties(jsonObject)
     }
+    
 }

--- a/app/src/main/java/com/safeboda/commons/analytics/provider/amplitude/AmplitudeAnalyticsProvider.kt
+++ b/app/src/main/java/com/safeboda/commons/analytics/provider/amplitude/AmplitudeAnalyticsProvider.kt
@@ -1,0 +1,35 @@
+package com.safeboda.commons.analytics.provider.amplitude
+
+import android.app.Application
+import com.amplitude.api.Amplitude
+import com.safeboda.commons.R
+import com.safeboda.commons.analytics.entity.AnalyticsEvent
+import com.safeboda.commons.analytics.entity.AnalyticsUser
+import com.safeboda.commons.analytics.provider.AnalyticsProvider
+
+class AmplitudeAnalyticsProvider(app: Application) : AnalyticsProvider {
+    private val amplitude = Amplitude.getInstance()
+        .initialize(app.baseContext, app.getString(R.))
+        .enableForegroundTracking(app)
+
+    override fun setUser(user: AnalyticsUser) {
+        amplitude.userId = user.id.toString()
+        amplitude.setUserProperties()
+    }
+
+    override fun clearUser() {
+        amplitude.clearUserProperties()
+    }
+
+    override fun setUserLogged() {
+        amplitude.
+    }
+
+    override fun setUserNotLogged() {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun track(event: AnalyticsEvent) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+}

--- a/app/src/main/java/com/safeboda/commons/analytics/provider/amplitude/AmplitudeAnalyticsProvider.kt
+++ b/app/src/main/java/com/safeboda/commons/analytics/provider/amplitude/AmplitudeAnalyticsProvider.kt
@@ -14,7 +14,7 @@ class AmplitudeAnalyticsProvider(app: Application, apiKey: String) : AnalyticsPr
 
     companion object {
         private const val JSON_USER_MAIL = "mail"
-        private const val JSON_USER_AGE = "age"
+        private const val JSON_USER_ID = "id"
 
         private const val JSON_USER_LOGGED_IN = "is_user_logged_in"
     }
@@ -22,7 +22,7 @@ class AmplitudeAnalyticsProvider(app: Application, apiKey: String) : AnalyticsPr
     override fun setUser(user: AnalyticsUser) {
         val jsonObject = JSONObject().apply {
             put(JSON_USER_MAIL, user.email)
-            put(JSON_USER_AGE, user.id)
+            put(JSON_USER_ID, user.id)
         }
 
         amplitude.setUserProperties(jsonObject)

--- a/app/src/main/java/com/safeboda/commons/analytics/provider/amplitude/AmplitudeAnalyticsProvider.kt
+++ b/app/src/main/java/com/safeboda/commons/analytics/provider/amplitude/AmplitudeAnalyticsProvider.kt
@@ -39,6 +39,12 @@ class AmplitudeAnalyticsProvider(app: Application, apiKey: String) : AnalyticsPr
     }
 
     override fun track(event: AnalyticsEvent) {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        val jsonObject = JSONObject()
+
+        event.getProperties().forEach {
+            jsonObject.put(it.key.name, it.value.getSafeValue())
+        }
+
+        amplitude.logEvent(event.name, jsonObject)
     }
 }

--- a/app/src/main/res/values/api_keys.xml
+++ b/app/src/main/res/values/api_keys.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="amplitude_api_key">test123</string>
+</resources>

--- a/app/src/main/res/values/api_keys.xml
+++ b/app/src/main/res/values/api_keys.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="amplitude_api_key">test123</string>
-</resources>

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -27,4 +27,7 @@ ext {
     junitVersion = '4.12'
     mockitoKotlinVersion = '2.2.0'
     mockitoInlineVersion = '2.22.0'
+
+    //Amplitude
+    amplitudeVersion = '2.14.1'
 }


### PR DESCRIPTION
## Create the Amplitude analytics provider

[JIRA Issue: MOB-13](https://safeboda.atlassian.net/browse/MOB-13)

#### Description
Amplitude implementation

#### Task status

| Status |
| ------ |
| CLOSES |

#### How to test it manually

- Select the <b>release</b> build variant and build it
- Navigate to `/build/generated/outputs/aar/app-release.aar` 
- Import the .aar file in a new Android proyect. Please follow this Medium post: "*https://medium.com/@notestomyself/how-to-include-external-aar-file-using-gradle-6604b378e808*"
- Add the Amplitude sdk in the app build.gradle (*This won't be necessary when we upload it to bintray*) "*implementation 'com.amplitude:android-sdk:2.16.0'*"
- Setup the `MainActivity.kt`to something like this

```kotlin
class MainActivity : AppCompatActivity() {
    private lateinit var amplitudeAnalyticsProvider: AmplitudeAnalyticsProvider

    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)
        setContentView(R.layout.activity_main)

        amplitudeAnalyticsProvider = AmplitudeAnalyticsProvider(application, "7484d5ec8cf981ddd54d77a006a971ff")

        val analyticsUser = AnalyticsUser(123, "something@safeboda.com")
        
        amplitudeAnalyticsProvider.setUser(analyticsUser)
    }

    override fun onResume() {
        amplitudeAnalyticsProvider.setUserLogged()
        super.onResume()
    }

    override fun onPause() {
        amplitudeAnalyticsProvider.setUserNotLogged()
        super.onPause()
    }
}
```
- Execute the app and wait for the results at the bottom of the project in amplitude (https://analytics.amplitude.com/safeboda/settings/projects/249833). You should see a message like this: <b>"We hear you loud and clear!"</b> or maybe you have to check the dashboard looking for the most recent events (?)