### PR TITLE
Mob 31 : Google Analytics Provider

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+android-commons

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Reformat" enabled="true" level="ERROR" enabled_by_default="true" />
+  </profile>
+</component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,10 +38,3 @@ dependencies {
 
     implementation "com.google.firebase:firebase-analytics:$googleAnalyticsVersion"
 }
-
-
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
-    kotlinOptions {
-        freeCompilerArgs = ["-XXLanguage:+InlineClasses"]
-    }
-}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 
     androidTestImplementation "androidx.test:runner:$androidTestRunnerVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidTestEspressoVersion"
+
+    implementation "com.google.firebase:firebase-analytics:$googleAnalyticsVersion"
 }
 
 

--- a/app/src/main/java/com/safeboda/commons/analytics/entity/AnalyticsEvent.kt
+++ b/app/src/main/java/com/safeboda/commons/analytics/entity/AnalyticsEvent.kt
@@ -3,6 +3,6 @@ package com.safeboda.commons.analytics.entity
 interface AnalyticsEvent {
     val name: String
 
-    fun getProperties(): Map<AnalyticsProperty, AnalyticsValue<out Any>>
+    fun getProperties(): Map<String, AnalyticsValue<out Any>>
 }
 

--- a/app/src/main/java/com/safeboda/commons/analytics/entity/AnalyticsProperty.kt
+++ b/app/src/main/java/com/safeboda/commons/analytics/entity/AnalyticsProperty.kt
@@ -1,3 +1,0 @@
-package com.safeboda.commons.analytics.entity
-
-inline class AnalyticsProperty(val name: String)

--- a/app/src/main/java/com/safeboda/commons/analytics/entity/AnalyticsUser.kt
+++ b/app/src/main/java/com/safeboda/commons/analytics/entity/AnalyticsUser.kt
@@ -1,6 +1,6 @@
 package com.safeboda.commons.analytics.entity
 
-class AnalyticsUser(
+data class AnalyticsUser(
     val id: Long,
-    val email: String
+    val userIdentifier: String
 )

--- a/app/src/main/java/com/safeboda/commons/analytics/entity/PropertyValues.kt
+++ b/app/src/main/java/com/safeboda/commons/analytics/entity/PropertyValues.kt
@@ -1,0 +1,5 @@
+package com.safeboda.commons.analytics.entity
+
+internal const val USER_ID = "user_id"
+internal const val USER_IDENTIFIER = "user_identifier"
+internal const val IS_USER_LOGGED_IN = "is_user_logged_in"

--- a/app/src/main/java/com/safeboda/commons/analytics/provider/GoogleAnalyticsProvider.kt
+++ b/app/src/main/java/com/safeboda/commons/analytics/provider/GoogleAnalyticsProvider.kt
@@ -1,0 +1,60 @@
+package com.safeboda.commons.analytics.provider
+
+import android.content.Context
+import android.os.Bundle
+import com.google.firebase.analytics.FirebaseAnalytics
+import com.safeboda.commons.analytics.entity.AnalyticsEvent
+import com.safeboda.commons.analytics.entity.AnalyticsUser
+
+class GoogleAnalyticsProvider(
+    context: Context
+) : AnalyticsProvider {
+
+    private var firebaseAnalytics: FirebaseAnalytics = FirebaseAnalytics.getInstance(context)
+
+    override fun setUser(user: AnalyticsUser) {
+        firebaseAnalytics.setUserId(user.id.toString())
+        firebaseAnalytics.setUserProperty("user_identifier", user.userIdentifier)
+    }
+
+    override fun clearUser() {
+        firebaseAnalytics.setUserId(null)
+        firebaseAnalytics.setUserProperty("user_identifier", null)
+    }
+
+    override fun setUserLogged() {
+        setLoginEvent(true)
+    }
+
+    override fun setUserNotLogged() {
+        setLoginEvent(false)
+    }
+
+    private fun setLoginEvent(isLogged: Boolean) {
+        val bundle = Bundle().apply {
+            putBoolean("is_user_logged_in", isLogged)
+        }
+        firebaseAnalytics.logEvent(FirebaseAnalytics.Event.LOGIN, bundle)
+    }
+
+    override fun track(event: AnalyticsEvent) {
+        val bundle = Bundle()
+
+        for ((propertyName, value) in event.getProperties()) {
+            when (value.getSafeValue()) {
+                is List<*> -> (value.getSafeValue() as List<*>).forEach { propertyValue ->
+                    bundle.putString(propertyName, propertyValue.toString())
+                }
+                is Boolean -> bundle.putBoolean(propertyName, value.getSafeValue() as Boolean)
+                is Long -> bundle.putLong(propertyName, value.getSafeValue() as Long)
+                is Int -> bundle.putInt(propertyName, value.getSafeValue() as Int)
+                is Float -> bundle.putFloat(propertyName, value.getSafeValue() as Float)
+                is Double -> bundle.putDouble(propertyName, value.getSafeValue() as Double)
+                else -> bundle.putString(propertyName, value.getSafeValue().toString())
+            }
+        }
+
+        firebaseAnalytics.logEvent(event.name, bundle)
+    }
+
+}

--- a/app/src/main/java/com/safeboda/commons/analytics/provider/amplitude/AmplitudeAnalyticsProvider.kt
+++ b/app/src/main/java/com/safeboda/commons/analytics/provider/amplitude/AmplitudeAnalyticsProvider.kt
@@ -2,28 +2,23 @@ package com.safeboda.commons.analytics.provider.amplitude
 
 import android.app.Application
 import com.amplitude.api.Amplitude
-import com.safeboda.commons.analytics.entity.AnalyticsEvent
-import com.safeboda.commons.analytics.entity.AnalyticsUser
+import com.safeboda.commons.analytics.entity.*
 import com.safeboda.commons.analytics.provider.AnalyticsProvider
 import org.json.JSONObject
 
-class AmplitudeAnalyticsProvider(app: Application, apiKey: String) : AnalyticsProvider {
+class AmplitudeAnalyticsProvider(
+    app: Application,
+    apiKey: String
+) : AnalyticsProvider {
 
     private val amplitude = Amplitude.getInstance()
         .initialize(app.baseContext, apiKey)
         .enableForegroundTracking(app)
 
-    companion object {
-        private const val JSON_USER_MAIL = "mail"
-        private const val JSON_USER_ID = "id"
-
-        private const val JSON_USER_LOGGED_IN = "is_user_logged_in"
-    }
-
     override fun setUser(user: AnalyticsUser) {
         val jsonObject = JSONObject().apply {
-            put(JSON_USER_MAIL, user.email)
-            put(JSON_USER_ID, user.id)
+            put(USER_ID, user.id)
+            put(USER_IDENTIFIER, user.userIdentifier)
         }
 
         amplitude.setUserProperties(jsonObject)
@@ -45,7 +40,7 @@ class AmplitudeAnalyticsProvider(app: Application, apiKey: String) : AnalyticsPr
         val jsonObject = JSONObject()
 
         event.getProperties().forEach {
-            jsonObject.put(it.key.name, it.value.getSafeValue())
+            jsonObject.put(it.key, it.value.getSafeValue())
         }
 
         amplitude.logEvent(event.name, jsonObject)
@@ -53,10 +48,10 @@ class AmplitudeAnalyticsProvider(app: Application, apiKey: String) : AnalyticsPr
 
     private fun setUserSessionStatus(isLoggedIn: Boolean) {
         val jsonObject = JSONObject().apply {
-            put(JSON_USER_LOGGED_IN, isLoggedIn)
+            put(IS_USER_LOGGED_IN, isLoggedIn)
         }
 
         amplitude.setUserProperties(jsonObject)
     }
-    
+
 }

--- a/app/src/main/java/com/safeboda/commons/analytics/provider/google/GoogleAnalyticsProvider.kt
+++ b/app/src/main/java/com/safeboda/commons/analytics/provider/google/GoogleAnalyticsProvider.kt
@@ -1,10 +1,13 @@
-package com.safeboda.commons.analytics.provider
+package com.safeboda.commons.analytics.provider.google
 
 import android.content.Context
 import android.os.Bundle
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.safeboda.commons.analytics.entity.AnalyticsEvent
 import com.safeboda.commons.analytics.entity.AnalyticsUser
+import com.safeboda.commons.analytics.entity.IS_USER_LOGGED_IN
+import com.safeboda.commons.analytics.entity.USER_IDENTIFIER
+import com.safeboda.commons.analytics.provider.AnalyticsProvider
 
 class GoogleAnalyticsProvider(
     context: Context
@@ -14,12 +17,12 @@ class GoogleAnalyticsProvider(
 
     override fun setUser(user: AnalyticsUser) {
         firebaseAnalytics.setUserId(user.id.toString())
-        firebaseAnalytics.setUserProperty("user_identifier", user.userIdentifier)
+        firebaseAnalytics.setUserProperty(USER_IDENTIFIER, user.userIdentifier)
     }
 
     override fun clearUser() {
         firebaseAnalytics.setUserId(null)
-        firebaseAnalytics.setUserProperty("user_identifier", null)
+        firebaseAnalytics.setUserProperty(USER_IDENTIFIER, null)
     }
 
     override fun setUserLogged() {
@@ -32,7 +35,7 @@ class GoogleAnalyticsProvider(
 
     private fun setLoginEvent(isLogged: Boolean) {
         val bundle = Bundle().apply {
-            putBoolean("is_user_logged_in", isLogged)
+            putBoolean(IS_USER_LOGGED_IN, isLogged)
         }
         firebaseAnalytics.logEvent(FirebaseAnalytics.Event.LOGIN, bundle)
     }

--- a/app/src/test/java/com/safeboda/commons/analytics/factory/AnalyticsEventFactory.kt
+++ b/app/src/test/java/com/safeboda/commons/analytics/factory/AnalyticsEventFactory.kt
@@ -7,8 +7,8 @@ class AnalyticsEventFactory {
 
     companion object {
         fun providesAnalyticsEvent(
-            email: String = "manuel@safeboda.com"
-        ) = TestAnalyticEvent.UnitTestAnalyticEvent(email)
+            phoneNumber: String = "+34662712381"
+        ) = TestAnalyticEvent.UnitTestAnalyticEvent(phoneNumber)
     }
 
     sealed class TestAnalyticEvent(
@@ -21,7 +21,7 @@ class AnalyticsEventFactory {
         ) : TestAnalyticEvent(name = "unit_test_event", testValue = testValue) {
 
             override fun getProperties(): Map<String, AnalyticsValue<out Any>> =
-                mapOf("passenger_email" to AnalyticsValue(testValue))
+                mapOf("passenger_phone_number" to AnalyticsValue(testValue))
 
         }
 

--- a/app/src/test/java/com/safeboda/commons/analytics/factory/AnalyticsEventFactory.kt
+++ b/app/src/test/java/com/safeboda/commons/analytics/factory/AnalyticsEventFactory.kt
@@ -1,7 +1,6 @@
 package com.safeboda.commons.analytics.factory
 
 import com.safeboda.commons.analytics.entity.AnalyticsEvent
-import com.safeboda.commons.analytics.entity.AnalyticsProperty
 import com.safeboda.commons.analytics.entity.AnalyticsValue
 
 class AnalyticsEventFactory {
@@ -21,8 +20,8 @@ class AnalyticsEventFactory {
             override val testValue: String
         ) : TestAnalyticEvent(name = "unit_test_event", testValue = testValue) {
 
-            override fun getProperties(): Map<AnalyticsProperty, AnalyticsValue<out Any>> =
-                mapOf(AnalyticsProperty(name = "passenger_email") to AnalyticsValue(testValue))
+            override fun getProperties(): Map<String, AnalyticsValue<out Any>> =
+                mapOf("passenger_email" to AnalyticsValue(testValue))
 
         }
 

--- a/app/src/test/java/com/safeboda/commons/analytics/factory/AnalyticsUserFactory.kt
+++ b/app/src/test/java/com/safeboda/commons/analytics/factory/AnalyticsUserFactory.kt
@@ -7,10 +7,10 @@ class AnalyticsUserFactory {
     companion object {
         fun providesAnalyticsUser(
             id: Long = 1234,
-            email: String = "user@safeboda.com"
+            phoneNumber: String = "+34666111222"
         ) = AnalyticsUser(
             id = id,
-            email = email
+            userIdentifier = phoneNumber
         )
     }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -28,6 +28,9 @@ ext {
     mockitoKotlinVersion = '2.2.0'
     mockitoInlineVersion = '2.22.0'
 
+    // Google Analytics
+    googleAnalyticsVersion = '17.2.0'
+
     //Amplitude
     amplitudeVersion = '2.14.1'
 }


### PR DESCRIPTION
## Google Analytics Provider

[JIRA Issue: MOB 31](https://safeboda.atlassian.net/browse/MOB-31)

#### Description
Google Analytics implementation.

Logcat that shows registering the events:
![image](https://user-images.githubusercontent.com/20324156/66040436-af536f00-e517-11e9-8a8b-1e9080403078.png)

#### Task status

| Status |
| ------ |
| CLOSES |

#### How to test it manually

- Select the <b>release</b> build variant and build it
- Navigate to `app/build/outputs/aar/app-release.aar` 
- Import the .aar file into the Passenger App. Please follow this Medium post: "*https://medium.com/@notestomyself/how-to-include-external-aar-file-using-gradle-6604b378e808*"
- Setup the `SafeBodaApplication`:

```kotlin
class SafeBodaApplication : DaggerApplication() {

    override fun onCreate() {
        GoogleAnalyticsProvider(this).apply {
                setUser(AnalyticsUser(1, "test_user"))
                setUserLogged()
            }
    }

}
```
- Execute the app and wait for the results inside [Firebase](https://console.firebase.google.com/project/safeboda-debug/analytics/app/android:com.safeboda.driver/events~2Foverview%3Ft=1570015058364&fpn=902662667270&swu=1&sgu=1&sus=not_upgraded&params=_u..pageSize%253D25%2526_r..layout.pageNumber%253D0&cs=app.m.events.overview&g=1) (they usually take a day in appear) project.
