### PR TITLE
App 555 : Limit the String of the event name to 40 char

### DIFF
--- a/app/src/main/java/com/safeboda/commons/analytics/entity/AnalyticsEventFactory.kt
+++ b/app/src/main/java/com/safeboda/commons/analytics/entity/AnalyticsEventFactory.kt
@@ -1,10 +1,12 @@
 package com.safeboda.commons.analytics.entity
 
+import androidx.annotation.Size
+
 data class AnalyticsEventFactory(override val name: String) : AnalyticsEvent(name) {
 
     companion object {
         fun <T : Any?> createAnalyticsEvent(
-            name: String,
+            @Size(max = 40) name: String,
             properties: List<Pair<String, T>> = listOf()
         ) = AnalyticsEventFactory(name).apply {
             properties.forEach {
@@ -13,7 +15,7 @@ data class AnalyticsEventFactory(override val name: String) : AnalyticsEvent(nam
         }
 
         fun <T : Any?> createAnalyticsEventWithListValues(
-            name: String,
+            @Size(max = 40) name: String,
             pair: Pair<String, List<T>>
         ) = AnalyticsEventFactory(name).apply {
             addListOfProperties(pair.first, pair.second)


### PR DESCRIPTION
## Limit the String of the event name to 40 char

[JIRA Issue: APP-555](https://safeboda.atlassian.net/browse/APP-555)

#### Description
Add @SiZe(max = 40) from AndroidX annotations to the name of the event

#### Task status

| Status |
| ------ |
| CLOSES |

#### How to test it manually
Create a `createAnalyticsEvent` or `createAnalyticsEventWithListValues` with more than 40 char
