### PR TITLE
App 680 : User properties wrong merge

### DIFF
--- a/app/src/main/java/com/safeboda/commons/analytics/provider/CleverTapAnalyticsProvider.kt
+++ b/app/src/main/java/com/safeboda/commons/analytics/provider/CleverTapAnalyticsProvider.kt
@@ -19,13 +19,11 @@ class CleverTapAnalyticsProvider(
             USER_PHONE to user.identifier
         )
         profileUpdate.putAll(user.getProperties())
-        cleverTap?.pushProfile(profileUpdate)
+        cleverTap?.onUserLogin(profileUpdate)
     }
 
     override fun clearUser(user: AnalyticsUser) {
-        user.getProperties().forEach { (key: String, _: Any?) ->
-            cleverTap?.removeValueForKey(key)
-        }
+        // NO-OP
     }
 
     override fun setUserLogged() {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,8 +2,8 @@ ext {
     // Android
     minSdkVersion = 19
     targetSdkVersion = 28
-    versionCode = 12
-    versionName = "0.0.12"
+    versionCode = 14
+    versionName = "0.0.14"
     androidCompileSdkVersion = 28
     androidCoreVersion = '1.1.0'
     androidTestRunnerVersion = '1.2.0'


### PR DESCRIPTION
## Title of the feature/bug/chore

[JIRA Issue: APP-680](https://safeboda.atlassian.net/browse/APP-680)

#### Description
Login two different user accounts on the same device is causing a wrong merge in the user properties. Following the docs, CleverTap has a way to deal with different user profiles on the same device.

[CleverTap User docs](https://developer.clevertap.com/docs/concepts-user-profiles#section-maintaining-multiple-user-profiles-on-the-same-device)

Note: It’s possible to remove the login inside `clearUser` for the CleverTap client.

#### Task status
| Status |
| ------ |
| CLOSES |

#### How to test it manually
Testable only adding the versión `0.0.14` to the apps.
