### PR TITLE
App 716 : Update Clever Tap

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
-    implementation "androidx.appcompat:appcompat:$androidCoreVersion"
+    implementation "androidx.appcompat:appcompat:$androidAppCompatVersion"
     implementation "androidx.core:core-ktx:$androidCoreVersion"
 
     implementation "com.google.firebase:firebase-analytics:$googleAnalyticsVersion"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation "com.amplitude:android-sdk:$amplitudeVersion"
 
     api "com.clevertap.android:clevertap-android-sdk:$cleverTapVersion"
+    api "com.android.installreferrer:installreferrer:$instalReferrerVersion"
 
     testImplementation "junit:junit:$junitVersion"
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$mockitoKotlinVersion"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -22,7 +22,10 @@ ext {
     amplitudeVersion = '2.23.2'
 
     // Clever Tap
-    cleverTapVersion = '3.6.3'
+    cleverTapVersion = '3.6.4'
+
+    // InstallReferrer
+    instalReferrerVersion = '1.1.1'
 
     //Bintray
     bintrayRepo = 'android'

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,8 +2,8 @@ ext {
     // Android
     minSdkVersion = 19
     targetSdkVersion = 28
-    versionCode = 14
-    versionName = "0.0.14"
+    versionCode = 15
+    versionName = "0.0.15"
     androidCompileSdkVersion = 28
     androidCoreVersion = '1.2.0'
     androidAppCompatVersion = '1.1.0'

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,7 +5,8 @@ ext {
     versionCode = 14
     versionName = "0.0.14"
     androidCompileSdkVersion = 28
-    androidCoreVersion = '1.1.0'
+    androidCoreVersion = '1.2.0'
+    androidAppCompatVersion = '1.1.0'
     androidTestRunnerVersion = '1.2.0'
     androidTestEspressoVersion = '3.2.0'
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -16,7 +17,7 @@ ext {
     mockitoInlineVersion = '2.22.0'
 
     // Google Analytics
-    googleAnalyticsVersion = '17.2.2'
+    googleAnalyticsVersion = '17.2.3'
 
     //Amplitude
     amplitudeVersion = '2.23.2'


### PR DESCRIPTION
## App 716 : Update Clever Tap

[JIRA Issue: APP-716](https://safeboda.atlassian.net/browse/APP-716)

#### Description
Google has made a change to how they retrieve referral information from the Play Store. They will stop broadcasting install_referrer intents from March 1, 2020. CleverTap uses this data to track organic app installs on Android.

Instead, the Play Install Referrer API is the new mechanism that provides the same data. This change requires that all CleverTap SDKs be upgraded to the latest version immediately to ensure continuity in the collection of organic installs data as a part of our utm_visited event

**REQUIRED ACTIONS**
- Update to the most recent version of the Android SDK (v3.6.4).

- Add the following dependency to your app build.gradle file:
`api "com.android.installreferrer:installreferrer:$instalReferrerVersion"`

#### Task status

| Status |
| ------ |
| CLOSES |